### PR TITLE
Add category breakdown for expenses

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,9 @@
                 const categoryBreakdown = document.getElementById('categoryBreakdown');
                 const categoryBreakdownContent = document.getElementById('categoryBreakdownContent');
                 
+                const urlParams = new URLSearchParams(window.location.search);
+                const showBreakdown = urlParams.get('breakdown') === 'true';
+                
                 if (!data.length) {
                     tableBody.innerHTML = `
                         <tr>
@@ -318,27 +321,31 @@
                     return;
                 }
 
-                const categoryTotals = {};
-                data.forEach(expense => {
-                    if (!categoryTotals[expense.category]) {
-                        categoryTotals[expense.category] = 0;
-                    }
-                    categoryTotals[expense.category] += expense.amount;
-                });
+                if (showBreakdown) {
+                    const categoryTotals = {};
+                    data.forEach(expense => {
+                        if (!categoryTotals[expense.category]) {
+                            categoryTotals[expense.category] = 0;
+                        }
+                        categoryTotals[expense.category] += expense.amount;
+                    });
 
-                const sortedCategories = Object.entries(categoryTotals)
-                    .sort(([,a], [,b]) => b - a);
+                    const sortedCategories = Object.entries(categoryTotals)
+                        .sort(([,a], [,b]) => b - a);
 
-                categoryBreakdownContent.innerHTML = sortedCategories.map(([category, total]) => `
-                    <div class="mb-2">
-                        <div class="d-flex justify-content-between">
-                            <span>${category}:</span>
-                            <span class="fw-bold">$${formatNumberWithCommas(total)}</span>
+                    categoryBreakdownContent.innerHTML = sortedCategories.map(([category, total]) => `
+                        <div class="mb-2">
+                            <div class="d-flex justify-content-between">
+                                <span>${category}:</span>
+                                <span class="fw-bold">$${formatNumberWithCommas(total)}</span>
+                            </div>
                         </div>
-                    </div>
-                `).join('');
+                    `).join('');
 
-                categoryBreakdown.style.display = 'block';
+                    categoryBreakdown.style.display = 'block';
+                } else {
+                    categoryBreakdown.style.display = 'none';
+                }
 
                 data.sort((a, b) => a.date < b.date ? 1 : -1); // Sort by date string directly
                 tableBody.innerHTML = data.map(expense => `

--- a/index.html
+++ b/index.html
@@ -149,6 +149,10 @@
                             <tbody id="expenseTable"></tbody>
                         </table>
                     </div>
+                    <div id="categoryBreakdown" class="mb-4" style="display: none;">
+                        <h5 class="modal-title fw-bold">Spending by Category</div>
+                        <div class="row" id="categoryBreakdownContent"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -299,6 +303,8 @@
                 });
 
                 const tableBody = document.getElementById('expenseTable');
+                const categoryBreakdown = document.getElementById('categoryBreakdown');
+                const categoryBreakdownContent = document.getElementById('categoryBreakdownContent');
                 
                 if (!data.length) {
                     tableBody.innerHTML = `
@@ -308,8 +314,31 @@
                             </td>
                         </tr>
                     `;
+                    categoryBreakdown.style.display = 'none';
                     return;
                 }
+
+                const categoryTotals = {};
+                data.forEach(expense => {
+                    if (!categoryTotals[expense.category]) {
+                        categoryTotals[expense.category] = 0;
+                    }
+                    categoryTotals[expense.category] += expense.amount;
+                });
+
+                const sortedCategories = Object.entries(categoryTotals)
+                    .sort(([,a], [,b]) => b - a);
+
+                categoryBreakdownContent.innerHTML = sortedCategories.map(([category, total]) => `
+                    <div class="mb-2">
+                        <div class="d-flex justify-content-between">
+                            <span>${category}:</span>
+                            <span class="fw-bold">$${formatNumberWithCommas(total)}</span>
+                        </div>
+                    </div>
+                `).join('');
+
+                categoryBreakdown.style.display = 'block';
 
                 data.sort((a, b) => a.date < b.date ? 1 : -1); // Sort by date string directly
                 tableBody.innerHTML = data.map(expense => `


### PR DESCRIPTION
In order to have more visibility on how much is spent per category, we need to add a "Spending by Category" breakdown feature. This PR introduces new UI elements for displaying category-wise spending, logic for calculating and sorting category totals, and dynamic rendering of the breakdown content.


<img width="523" height="380" alt="image" src="https://github.com/user-attachments/assets/4f5161d0-ad7b-4765-aa38-bc2e3841ce86" />
